### PR TITLE
add more AVIF encoding variants to the comparison (enable variants by uncommenting)

### DIFF
--- a/compute_BD_rates.py
+++ b/compute_BD_rates.py
@@ -19,6 +19,7 @@ __status__ = "Development"
 
 RateQualityPoint = namedtuple('RateQualityPoint', ['bpp', 'quality', 'target_metric', 'target_value'])
 BD_RATE_EXCEPTION_STRING = 'BD_RATE_EXCEPTION'
+CODEC_PRINT_LENGTH = 22
 
 
 def get_unique_sources_sorted(connection):
@@ -86,7 +87,7 @@ def print_bd_rates(bdrates_various_metrics, codec, unique_sources, black_list_so
             if source not in black_list_source_various_metrics[metric]:
                 bdrates_this_codec_various_metrics[metric].append(bdrates_various_metrics[metric][codec][source])
         print(print_string)
-    result = codec.ljust(16)
+    result = codec.ljust(CODEC_PRINT_LENGTH)
     result_local = result
     for metric in list_of_metrics:
         result += '{}'.format(get_formatted_mean_bdrate(mean(bdrates_this_codec_various_metrics[metric])))
@@ -111,10 +112,16 @@ def main(argv):
 
     baseline_codec = 'jpeg'
     sub_sampling_arr = ['420', '444']
+    # sub_sampling_arr = ['444']
     codecs = ['jpeg-mse', 'jpeg-ms-ssim', 'jpeg-im', 'jpeg-hvs-psnr', 'webp', 'kakadu-mse', 'kakadu-visual', 'openjpeg',
               'hevc', 'avif-mse', 'avif-ssim',
               'avifenc-sp-0', 'avifenc-sp-2', 'avifenc-sp-4', 'avifenc-sp-6', 'avifenc-sp-8',
               'avifenc-sp-0-crf', 'avifenc-sp-2-crf', 'avifenc-sp-4-crf', 'avifenc-sp-6-crf', 'avifenc-sp-8-crf']
+    # codecs = ['avifenc-sp-0', 'avifenc-sp-2', 'avifenc-sp-4', 'avifenc-sp-6', 'avifenc-sp-8',
+    #           'avifenc_ssim-sp-0', 'avifenc_ssim-sp-2', 'avifenc_ssim-sp-4', 'avifenc_ssim-sp-6', 'avifenc_ssim-sp-8',
+    #           'avifenc-sp-0-crf', 'avifenc-sp-2-crf', 'avifenc-sp-4-crf', 'avifenc-sp-6-crf', 'avifenc-sp-8-crf',
+    #           'avifenc_ssim-sp-0-crf', 'avifenc_ssim-sp-2-crf', 'avifenc_ssim-sp-4-crf', 'avifenc_ssim-sp-6-crf',
+    #           'avifenc_ssim-sp-8-crf']
     metrics_for_BDRate = ['vmaf', 'ssim', 'ms_ssim', 'vif', 'adm2', 'psnr_y', 'psnr_avg']
     for sub_sampling in sub_sampling_arr:
         bdrates_various_metrics = dict()
@@ -156,11 +163,11 @@ def main(argv):
                                     black_list_source_various_metrics,
                                     metrics_for_BDRate)
             results[codec] = result
-        logger.info('\n\n===================' + '=' * 22 * len(metrics_for_BDRate))
+        logger.info('\n\n=======================' + '=' * 22 * len(metrics_for_BDRate))
         results_header = 'Results for subsampling {}'.format(sub_sampling)
         logger.info(results_header)
         logger.info('-' * len(results_header))
-        table_header = 'Codec'.ljust(16)
+        table_header = 'Codec'.ljust(CODEC_PRINT_LENGTH)
         for metric in metrics_for_BDRate:
             table_header += ' Mean BDRate-{}'.format(metric.upper()).rjust(22)
         logger.info(table_header)
@@ -168,7 +175,7 @@ def main(argv):
             if codec == 'webp' and sub_sampling == '444':
                 continue
             logger.info(results[codec])
-        logger.info('===================' + '=' * 22 * len(metrics_for_BDRate))
+        logger.info('=======================' + '=' * 22 * len(metrics_for_BDRate))
 
 
 if __name__ == '__main__':

--- a/script_compress_parallel.py
+++ b/script_compress_parallel.py
@@ -119,6 +119,26 @@ TUPLE_CODECS = (
     CodecType('avifenc-sp-8', True, 8, 62, 1, '444'),
     CodecType('avifenc-sp-8', True, 8, 62, 1, '444u'),
 
+    # CodecType('avifenc_ssim-sp-0', True, 8, 62, 1, '420'),
+    # CodecType('avifenc_ssim-sp-0', True, 8, 62, 1, '444'),
+    # CodecType('avifenc_ssim-sp-0', True, 8, 62, 1, '444u'),
+    #
+    # CodecType('avifenc_ssim-sp-2', True, 8, 62, 1, '420'),
+    # CodecType('avifenc_ssim-sp-2', True, 8, 62, 1, '444'),
+    # CodecType('avifenc_ssim-sp-2', True, 8, 62, 1, '444u'),
+    #
+    # CodecType('avifenc_ssim-sp-4', True, 8, 62, 1, '420'),
+    # CodecType('avifenc_ssim-sp-4', True, 8, 62, 1, '444'),
+    # CodecType('avifenc_ssim-sp-4', True, 8, 62, 1, '444u'),
+    #
+    # CodecType('avifenc_ssim-sp-6', True, 8, 62, 1, '420'),
+    # CodecType('avifenc_ssim-sp-6', True, 8, 62, 1, '444'),
+    # CodecType('avifenc_ssim-sp-6', True, 8, 62, 1, '444u'),
+    #
+    # CodecType('avifenc_ssim-sp-8', True, 8, 62, 1, '420'),
+    # CodecType('avifenc_ssim-sp-8', True, 8, 62, 1, '444'),
+    # CodecType('avifenc_ssim-sp-8', True, 8, 62, 1, '444u'),
+
     CodecType('avifenc-sp-0-crf', True, 8, 62, 1, '420'),
     CodecType('avifenc-sp-0-crf', True, 8, 62, 1, '444'),
     CodecType('avifenc-sp-0-crf', True, 8, 62, 1, '444u'),
@@ -138,6 +158,26 @@ TUPLE_CODECS = (
     CodecType('avifenc-sp-8-crf', True, 8, 62, 1, '420'),
     CodecType('avifenc-sp-8-crf', True, 8, 62, 1, '444'),
     CodecType('avifenc-sp-8-crf', True, 8, 62, 1, '444u'),
+
+    # CodecType('avifenc_ssim-sp-0-crf', True, 8, 62, 1, '420'),
+    # CodecType('avifenc_ssim-sp-0-crf', True, 8, 62, 1, '444'),
+    # CodecType('avifenc_ssim-sp-0-crf', True, 8, 62, 1, '444u'),
+    #
+    # CodecType('avifenc_ssim-sp-2-crf', True, 8, 62, 1, '420'),
+    # CodecType('avifenc_ssim-sp-2-crf', True, 8, 62, 1, '444'),
+    # CodecType('avifenc_ssim-sp-2-crf', True, 8, 62, 1, '444u'),
+    #
+    # CodecType('avifenc_ssim-sp-4-crf', True, 8, 62, 1, '420'),
+    # CodecType('avifenc_ssim-sp-4-crf', True, 8, 62, 1, '444'),
+    # CodecType('avifenc_ssim-sp-4-crf', True, 8, 62, 1, '444u'),
+    #
+    # CodecType('avifenc_ssim-sp-6-crf', True, 8, 62, 1, '420'),
+    # CodecType('avifenc_ssim-sp-6-crf', True, 8, 62, 1, '444'),
+    # CodecType('avifenc_ssim-sp-6-crf', True, 8, 62, 1, '444u'),
+    #
+    # CodecType('avifenc_ssim-sp-8-crf', True, 8, 62, 1, '420'),
+    # CodecType('avifenc_ssim-sp-8-crf', True, 8, 62, 1, '444'),
+    # CodecType('avifenc_ssim-sp-8-crf', True, 8, 62, 1, '444u'),
 
 )
 
@@ -646,7 +686,13 @@ def f(param, codec, image, width, height, temp_folder, subsampling):
         my_exec(cmd)
 
     elif codec in ['avifenc-sp-0', 'avifenc-sp-2', 'avifenc-sp-4', 'avifenc-sp-6', 'avifenc-sp-8',
-                   'avifenc-sp-0-crf', 'avifenc-sp-2-crf', 'avifenc-sp-4-crf', 'avifenc-sp-6-crf', 'avifenc-sp-8-crf'] \
+                   'avifenc_ssim-sp-0', 'avifenc_ssim-sp-2', 'avifenc_ssim-sp-4', 'avifenc_ssim-sp-6',
+                   'avifenc_ssim-sp-8',
+                   'avifenc-sp-0-crf', 'avifenc-sp-2-crf', 'avifenc-sp-4-crf', 'avifenc-sp-6-crf',
+                   'avifenc-sp-8-crf',
+                   'avifenc_ssim-sp-0-crf', 'avifenc_ssim-sp-2-crf', 'avifenc_ssim-sp-4-crf', 'avifenc_ssim-sp-6-crf',
+                   'avifenc_ssim-sp-8-crf'
+                   ] \
             and subsampling in ['420', '444u', '444']:
         min_QP = int(param) - 1
         max_QP = int(param) + 1
@@ -671,13 +717,17 @@ def f(param, codec, image, width, height, temp_folder, subsampling):
         if codec.endswith('crf'):
             # default tuning is PSNR; ssim can be added with "-a tune=ssim"
             cmd = ['/tools/libavif/build/avifenc', source_y4m, encoded_file, '-d', '8',
-                   '--nclx', '1/13/1', '--min', str(min_QP), '--max', str(max_QP),
+                   '--nclx', '1/13/6', '--min', str(min_QP), '--max', str(max_QP),
                    '-a', 'end-usage=q', '-a', 'cq-level={}'.format(crf_val),
                    '--speed', speed, '--codec', 'aom', '--jobs', '4']
         else:
             cmd = ['/tools/libavif/build/avifenc', source_y4m, encoded_file, '-d', '8',
-                   '--nclx', '1/13/1', '--min', str(min_QP), '--max', str(max_QP),
+                   '--nclx', '1/13/6', '--min', str(min_QP), '--max', str(max_QP),
                    '--speed', speed, '--codec', 'aom', '--jobs', '4']
+        if codec.find('ssim') > 0:
+            cmd.append('-a')
+            cmd.append('tune=ssim')
+        LOGGER.debug(cmd)
         my_exec(cmd)
 
         decoded_y4m = get_filename_with_temp_folder(temp_folder, 'decoded.y4m')


### PR DESCRIPTION
1) move to --nclx 1/13/6 for "avifenc" based encodes 2) add the AVIF encode variants with SSIM tuning based on advanced usage argument "-a tune=ssim"